### PR TITLE
Update the Firefox unsigned extension article to mention the need for a Developer or ESR build of Firefox

### DIFF
--- a/_posts/2020-11-26-installing-unsigned-extensions-permanently-to-firefox.md
+++ b/_posts/2020-11-26-installing-unsigned-extensions-permanently-to-firefox.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "Installing unsigned extensions permanently to Firefox"
+title:  "Installing unsigned extensions permanently to Firefox Developer edition"
 date:   2020-11-26 20:35:32 -0700
 categories: browser-extensions
 post_photo: assets/posts/install-unsigned-ext-firefox/post_photo.jpg
@@ -13,13 +13,17 @@ Sometimes you may need to test how the extension behaves when Firefox starts, or
 
 ## Summary
 
-Gladly, there is a simple solution:
+Gladly, there is a simple solution if you are using Firefox Developer or the ESR build:
 1. Update your extension manifest to include custom `browser_specific_settings`.
 2. Disable signature checks while installing extensions.
 3. Package your extension as a zip file.
 4. Install the extension.
 5. Enable signature checks while installing extensions.
 
+Learn more at https://support.mozilla.org/en-US/kb/add-on-signing-in-firefox.
+
+**Note that it is not possible to configure `xpinstall.signatures.required` in Firefox Release!**
+These steps will not work for you if you are using the stable version of Firefox.
 
 ### Step 1
 Update your `manifest.json` to include a new key, the `id` could be any email:


### PR DESCRIPTION
Hello! I found your post about installing unsigned extensions to Firefox permanently via Google Search:
https://wiringbits.net/browser-extensions/2020/11/27/installing-unsigned-extensions-permanently-to-firefox.html

I tried the steps myself but could not reproduce the successful end result you describe in your post.

I followed the steps exactly and created my archive file, then selected it in the dropdown in `about:addons` but I got a UI message telling me the extension was not verified. It had a link which led here:

https://support.mozilla.org/en-US/kb/add-on-signing-in-firefox

On this page it says the following:

> What are my options if I want to use an unsigned add-on? (advanced users)
> …
> Firefox [Extended Support Release (ESR)](https://www.mozilla.org/firefox/organizations/), Firefox [Developer Edition](https://www.mozilla.org/firefox/developer/) and [Nightly](https://nightly.mozilla.org/) versions of Firefox will allow you to override the setting to enforce the extension signing requirement, by changing the preference xpinstall.signatures.required to false in the [Firefox Configuration Editor](https://support.mozilla.org/en-US/kb/about-config-editor-firefox) (`about:config` page).

This indicates that Firefox Release doesn't allow this setting to change the policy (despite it being there).
I have more support for this information in the answer on this question posted here:
https://discourse.mozilla.org/t/what-is-the-easiest-way-to-install-a-local-unsigned-add-on-permanently/52005

I think either you are missing Firefox Developer (or ESR) and did not mention that in the post or you were using Firefox Release when writing the post in 2020, but since Mozilla locked down this setting to only apply in non-Release builds.

I'm sending in this PR so that you can consider updating the article to mention this.
I knew it was too good to be true when I came across it, but I had to try it just in case.
Unfortunately, Mozilla managed to disappoint so to save future Google Search travelers some time, I am proposing this change so other people know right away they need to succumb to use Firefox Developer or go through the pain of publishing their extensions via AMO (and possibly subject themselves to a cycle of week-long radio silences intertwined with commentless rejections :/).